### PR TITLE
#31 configure telegraf for better analysis

### DIFF
--- a/telegraf.conf
+++ b/telegraf.conf
@@ -526,3 +526,10 @@
     domains = ["www.alipay.com","www.wechat.com","www.baidu.com", "www.agora-space.com"]
     port = 53
     timeout = 2
+
+[[inputs.dns_query]]
+    servers = ["10.1.0.1", "10.1.0.2", "10.1.0.4"]
+    network = "udp"
+    domains = ["www.alipay.com","www.wechat.com","www.baidu.com", "www.agora-space.com"]
+    port = 53
+    timeout = 2

--- a/telegraf.conf
+++ b/telegraf.conf
@@ -204,6 +204,33 @@
     method = "GET"
     follow_redirects = true
 
+[[inputs.http_response]]
+    interval = "5s"
+    address = "http://13.107.21.200"
+    response_timeout = "10s"
+    method = "GET"
+    follow_redirects = false
+    [[inputs.http_response.tags]]
+        name = "bing.com_ip"
+
+[[inputs.http_response]]
+    interval = "5s"
+    address = "http://216.58.200.78"
+    response_timeout = "10s"
+    method = "GET"
+    follow_redirects = true
+    [[inputs.http_response.tags]]
+        name = "google.com_ip"
+
+[[inputs.http_response]]
+    interval = "5s"
+    address = "http://59.37.97.124"
+    response_timeout = "10s"
+    method = "GET"
+    follow_redirects = true
+    [[inputs.http_response.tags]]
+        name = "wechat.com_ip"
+
 ## HHTP queries chinese websites ##
 [[inputs.http_response]]
     interval = "5s"


### PR DESCRIPTION
Adding direct IP HTTP requests for wechat.com, bing.com and google.com and adding DNS queries for internal server.